### PR TITLE
Add tests with mock server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,21 +3,22 @@ module github.com/hashicorp/terraform-provider-scaffolding
 go 1.22.7
 
 require (
+	github.com/aep-dev/aep-lib-go v0.0.0-20250217200129-e8cdedc0dfd4
+	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-go v0.25.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.11.0
+	github.com/jarcoal/httpmock v1.3.1
 )
 
 require (
 	github.com/ProtonMail/go-crypto v1.1.0-alpha.2 // indirect
-	github.com/aep-dev/aep-lib-go v0.0.0-20250121233519-8bc026ce637e // indirect
 	github.com/agext/levenshtein v1.2.2 // indirect
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,10 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2 h1:bkyFVUP+ROOARdgCiJzNQo2V2kiB97LyUpzH9P6Hrlg=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.2/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/aep-dev/aep-lib-go v0.0.0-20241214201740-a1e57b9a0273 h1:Ti/n7Xko9nrr731O0f7iUewiTL1fiPA93A4/iSazW6M=
-github.com/aep-dev/aep-lib-go v0.0.0-20241214201740-a1e57b9a0273/go.mod h1:M+h1D6T2uIUPelmaEsJbjR6JhqKsTlPX3lxp25zQQsk=
 github.com/aep-dev/aep-lib-go v0.0.0-20250121233519-8bc026ce637e h1:fwCEENQV0LVH/HEkn6Egznu9FzsifNwnIW7qoYvs5jw=
 github.com/aep-dev/aep-lib-go v0.0.0-20250121233519-8bc026ce637e/go.mod h1:M+h1D6T2uIUPelmaEsJbjR6JhqKsTlPX3lxp25zQQsk=
+github.com/aep-dev/aep-lib-go v0.0.0-20250217200129-e8cdedc0dfd4 h1:+5Me30mM/iyK0A8AGWRL+eF4+eJ8UqD9LbXnLPc3Y0M=
+github.com/aep-dev/aep-lib-go v0.0.0-20250217200129-e8cdedc0dfd4/go.mod h1:M+h1D6T2uIUPelmaEsJbjR6JhqKsTlPX3lxp25zQQsk=
 github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXvaqE=
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
@@ -96,6 +96,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
+github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=
+github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
@@ -118,6 +120,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
@@ -143,8 +147,8 @@ github.com/skeema/knownhosts v1.2.2 h1:Iug2P4fLmDw9f41PB6thxUkNUkJzB5i+1/exaj40L
 github.com/skeema/knownhosts v1.2.2/go.mod h1:xYbVRSPxqBZFrdmDyMmsOs+uX1UZC3nTN3ThzgDxUwo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -58,7 +58,7 @@ func Create(ctx context.Context, r *api.Resource, c *http.Client, serverUrl stri
 }
 
 func Read(ctx context.Context, c *http.Client, serverUrl string, path string) (map[string]interface{}, error) {
-	url := fmt.Sprintf("%s/%s", serverUrl, path)
+	url := fmt.Sprintf("%s/%s", serverUrl, strings.TrimPrefix(path, "/"))
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
@@ -86,7 +86,7 @@ func Read(ctx context.Context, c *http.Client, serverUrl string, path string) (m
 }
 
 func Delete(ctx context.Context, c *http.Client, serverUrl string, path string) error {
-	url := fmt.Sprintf("%s/%s", serverUrl, path)
+	url := fmt.Sprintf("%s/%s", serverUrl, strings.TrimPrefix(path, "/"))
 
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
@@ -98,7 +98,7 @@ func Delete(ctx context.Context, c *http.Client, serverUrl string, path string) 
 }
 
 func Update(ctx context.Context, c *http.Client, serverUrl string, path string, body map[string]interface{}) error {
-	url := fmt.Sprintf("%s/%s", serverUrl, path)
+	url := fmt.Sprintf("%s/%s", serverUrl, strings.TrimPrefix(path, "/"))
 
 	reqBody, err := json.Marshal(body)
 	if err != nil {
@@ -116,11 +116,9 @@ func Update(ctx context.Context, c *http.Client, serverUrl string, path string, 
 
 func createBase(ctx context.Context, r *api.Resource, serverUrl string, parameters map[string]string, suffix string) string {
 	urlElems := []string{serverUrl}
-	tflog.Info(ctx, fmt.Sprintf("full pattern %s", r.Schema.XAEPResource.Patterns[0]))
-	patternElements := strings.Split(r.Schema.XAEPResource.Patterns[0], "/")
-	for i, elem := range patternElements {
+	for i, elem := range r.PatternElems {
 		tflog.Info(ctx, fmt.Sprintf("pattern elem %s", elem))
-		if i == len(patternElements)-1 {
+		if i == len(r.PatternElems)-1 {
 			tflog.Info(ctx, "skipping")
 			continue
 		}

--- a/internal/provider/data/resource.go
+++ b/internal/provider/data/resource.go
@@ -116,7 +116,11 @@ func ConvertValue(v Value) (interface{}, error) {
 	if v.List != nil {
 		list := make([]interface{}, len(*v.List))
 		for i, item := range *v.List {
-			list[i] = item
+			v2, err := ConvertValue(item)
+			if err != nil {
+				return nil, err
+			}
+			list[i] = v2
 		}
 		return list, nil
 	}

--- a/internal/provider/example_resource.go
+++ b/internal/provider/example_resource.go
@@ -118,6 +118,12 @@ func (r *ExampleResource) Create(ctx context.Context, req resource.CreateRequest
 
 	tflog.Info(ctx, fmt.Sprintf("resource state: %v", a))
 
+	_, ok := a["path"]
+	if !ok {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create example, expected path in resp: %q", a))
+	}
+	a["id"] = a["path"]
+
 	err = data.ToResource(a, dataPlan)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to marshal example, got error: %s", err))
@@ -162,6 +168,12 @@ func (r *ExampleResource) Read(ctx context.Context, req resource.ReadRequest, re
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read example, got error: %s", err))
 		return
 	}
+
+	_, ok = a["path"]
+	if !ok {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read example, expected path in resp: %q", a))
+	}
+	a["id"] = a["path"]
 
 	err = data.ToResource(a, dataResource)
 	if err != nil {
@@ -217,6 +229,12 @@ func (r *ExampleResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 	tflog.Info(ctx, fmt.Sprintf("Create response: %v", a))
+
+	_, ok = a["path"]
+	if !ok {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update example, expected path in resp: %q", a))
+	}
+	a["id"] = a["path"]
 
 	err = data.ToResource(a, dataResource)
 	if err != nil {

--- a/internal/provider/example_resource.go
+++ b/internal/provider/example_resource.go
@@ -52,7 +52,7 @@ func (r *ExampleResource) Metadata(ctx context.Context, req resource.MetadataReq
 }
 
 func (r *ExampleResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
-	attr, err := FullSchema(r.resource, r.openapi)
+	attr, err := FullSchema(r.resource)
 	if err != nil {
 		resp.Diagnostics.AddError("Schema error", fmt.Sprintf("Unable to create additional attributes for resource %s, got error: %s", r.name, err))
 		return
@@ -97,7 +97,7 @@ func (r *ExampleResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	parameters, err := Parameters(ctx, dataPlan, r.resource, r.openapi)
+	parameters, err := Parameters(ctx, dataPlan, r.resource)
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create parameters, got error: %s", err))
 		return
@@ -116,24 +116,14 @@ func (r *ExampleResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	tflog.Info(ctx, fmt.Sprintf("resource state: %v", a))
-
-	_, ok := a["path"]
-	if !ok {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to create example, expected path in resp: %q", a))
-	}
-	a["id"] = a["path"]
-
-	err = data.ToResource(a, dataPlan)
+	dataState, err := State(a, dataPlan, r.resource)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to marshal example, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Create: unable to create state, got error: %s", err))
 		return
+
 	}
-
-	tflog.Info(ctx, fmt.Sprintf("about to save: %v", dataPlan))
-
 	// Save data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, dataPlan)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, dataState)...)
 }
 
 func (r *ExampleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -169,22 +159,15 @@ func (r *ExampleResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	_, ok = a["path"]
-	if !ok {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read example, expected path in resp: %q", a))
-	}
-	a["id"] = a["path"]
-
-	err = data.ToResource(a, dataResource)
+	dataState, err := State(a, dataResource, r.resource)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to marshal example, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Read: unable to create state, got error: %s", err))
 		return
-	}
 
-	tflog.Info(ctx, fmt.Sprintf("about to save: %v", dataResource))
+	}
 
 	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, dataResource)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, dataState)...)
 }
 
 func (r *ExampleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -230,22 +213,15 @@ func (r *ExampleResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 	tflog.Info(ctx, fmt.Sprintf("Create response: %v", a))
 
-	_, ok = a["path"]
-	if !ok {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to update example, expected path in resp: %q", a))
-	}
-	a["id"] = a["path"]
-
-	err = data.ToResource(a, dataResource)
+	toBeState, err := State(a, dataResource, r.resource)
 	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to marshal example, got error: %s", err))
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Update: unable to create state, got error: %s", err))
 		return
-	}
 
-	tflog.Info(ctx, fmt.Sprintf("about to save: %v", dataResource))
+	}
 
 	// Save data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, dataResource)...)
+	resp.Diagnostics.Append(resp.State.Set(ctx, toBeState)...)
 }
 
 func (r *ExampleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/example_resource_test.go
+++ b/internal/provider/example_resource_test.go
@@ -18,29 +18,25 @@ func TestAccExampleResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccExampleResourceConfig("one"),
+				Config: testExamplePublisherConfig("my-pub", "pub-description"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("scaffolding_example.test", "configurable_attribute", "one"),
-					resource.TestCheckResourceAttr("scaffolding_example.test", "defaulted", "example value when not configured"),
-					resource.TestCheckResourceAttr("scaffolding_example.test", "id", "example-id"),
+					resource.TestCheckResourceAttr("scaffolding_publisher.my-pub", "description", "pub-description"),
+					resource.TestCheckResourceAttr("scaffolding_publisher.my-pub", "path", "/publishers/1"),
 				),
 			},
 			// ImportState testing
 			{
-				ResourceName:      "scaffolding_example.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-				// This is not normally necessary, but is here because this
-				// example code does not have an actual upstream service.
-				// Once the Read method is able to refresh information from
-				// the upstream service, this can be removed.
-				ImportStateVerifyIgnore: []string{"configurable_attribute", "defaulted"},
+				ResourceName:                         "scaffolding_publisher.my-pub",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "path",
 			},
 			// Update and Read testing
 			{
-				Config: testAccExampleResourceConfig("two"),
+				Config: testExamplePublisherConfig("my-pub", "pub-description2"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("scaffolding_example.test", "configurable_attribute", "two"),
+					resource.TestCheckResourceAttr("scaffolding_publisher.my-pub", "description", "pub-description2"),
+					resource.TestCheckResourceAttr("scaffolding_publisher.my-pub", "path", "/publishers/1"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -48,10 +44,11 @@ func TestAccExampleResource(t *testing.T) {
 	})
 }
 
-func testAccExampleResourceConfig(configurableAttribute string) string {
-	return fmt.Sprintf(`
-resource "scaffolding_example" "test" {
-  configurable_attribute = %[1]q
+func testExamplePublisherConfig(publisher string, description string) string {
+	f := fmt.Sprintf(`
+resource "scaffolding_publisher" %[1]q {
+  description = %[2]q
 }
-`, configurableAttribute)
+`, publisher, description)
+	return f
 }

--- a/internal/provider/example_resource_test.go
+++ b/internal/provider/example_resource_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestAccExampleResource(t *testing.T) {
+func TestPublisherResource(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		IsUnitTest:               true,
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -44,11 +44,56 @@ func TestAccExampleResource(t *testing.T) {
 	})
 }
 
+func TestBookResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:               true,
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testExampleBookConfig("my-book", "1", "my-pub"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("scaffolding_publisher.my-pub", "description", "pub-description"),
+					resource.TestCheckResourceAttr("scaffolding_publisher.my-pub", "path", "/publishers/1"),
+					resource.TestCheckResourceAttr("scaffolding_book.my-book", "price", "1"),
+					resource.TestCheckResourceAttr("scaffolding_book.my-book", "path", "/publishers/1/books/1"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: testExampleBookConfig("my-book", "3", "my-pub"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("scaffolding_publisher.my-pub", "description", "pub-description"),
+					resource.TestCheckResourceAttr("scaffolding_publisher.my-pub", "path", "/publishers/1"),
+					resource.TestCheckResourceAttr("scaffolding_book.my-book", "price", "3"),
+					resource.TestCheckResourceAttr("scaffolding_book.my-book", "path", "/publishers/1/books/1"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
 func testExamplePublisherConfig(publisher string, description string) string {
-	f := fmt.Sprintf(`
+	return fmt.Sprintf(`
 resource "scaffolding_publisher" %[1]q {
   description = %[2]q
 }
 `, publisher, description)
-	return f
+}
+
+func testExampleBookConfig(book string, price string, publisher string) string {
+	return fmt.Sprintf(`
+resource "scaffolding_publisher" %[3]q {
+  description = "pub-description"
+}
+
+resource "scaffolding_book" %[1]q {
+  price = %[2]q
+  publisher = scaffolding_publisher.%[3]s.path
+  published = true
+  isbn = ["1234"]
+}
+`, book, price, publisher)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,6 +30,8 @@ type ScaffoldingProvider struct {
 	generator *GeneratedProviderData
 
 	openapi *openapi.OpenAPI
+
+	client *http.Client
 }
 
 // ScaffoldingProviderModel describes the provider data model.
@@ -54,9 +56,8 @@ func (p *ScaffoldingProvider) Configure(ctx context.Context, req provider.Config
 	}
 
 	// Example client configuration for data sources and resources
-	client := http.DefaultClient
-	resp.DataSourceData = client
-	resp.ResourceData = client
+	resp.DataSourceData = p.client
+	resp.ResourceData = p.client
 }
 
 func (p *ScaffoldingProvider) Resources(ctx context.Context) []func() resource.Resource {
@@ -75,12 +76,13 @@ func (p *ScaffoldingProvider) Functions(ctx context.Context) []func() function.F
 	return []func() function.Function{}
 }
 
-func New(version string, g *GeneratedProviderData, oas *openapi.OpenAPI) func() provider.Provider {
+func New(version string, g *GeneratedProviderData, oas *openapi.OpenAPI, client *http.Client) func() provider.Provider {
 	return func() provider.Provider {
 		return &ScaffoldingProvider{
 			version:   version,
 			generator: g,
 			openapi:   oas,
+			client:    client,
 		}
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -4,11 +4,15 @@
 package provider
 
 import (
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/aep-dev/aep-lib-go/pkg/openapi"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/jarcoal/httpmock"
 )
 
 // testAccProtoV6ProviderFactories are used to instantiate a provider during
@@ -19,18 +23,96 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 	"scaffolding": func() (tfprotov6.ProviderServer, error) {
 		gen, err := CreateGeneratedProviderData("testdata/oas.yaml")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to create generated data %v", err)
 		}
 		oas, err := openapi.FetchOpenAPI("testdata/oas.yaml")
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to fetch oas spec %v", err)
 		}
-		return providerserver.NewProtocol6WithError(New("test", gen, oas)())()
+		mockClient := &http.Client{}
+		return providerserver.NewProtocol6WithError(New("test", gen, oas, mockClient)())()
 	},
 }
 
 func testAccPreCheck(t *testing.T) {
-	// You can add code here to run prior to any test case execution, for example assertions
-	// about the appropriate environment variables being set are common to see in a pre-check
-	// function.
+	httpmock.Activate()
+
+	allResources := make(map[string]interface{})
+	var bookCounter = 1
+	httpmock.RegisterResponder("POST", "http://localhost:8081/publishers",
+		func(req *http.Request) (*http.Response, error) {
+			var requestBody map[string]interface{}
+			err := json.NewDecoder(req.Body).Decode(&requestBody)
+			if err != nil {
+				return httpmock.NewStringResponse(400, ""), nil
+			}
+			allResources[fmt.Sprintf("%d", bookCounter)] = requestBody
+			requestBody["path"] = fmt.Sprintf("/publishers/%d", bookCounter)
+			bookCounter += 1
+			jsonRequestBody, err := json.Marshal(requestBody)
+			if err != nil {
+				return httpmock.NewStringResponse(500, ""), nil
+			}
+			return httpmock.NewStringResponse(201, string(jsonRequestBody)), nil
+		},
+	)
+
+	httpmock.RegisterResponder("GET", "=~^http://localhost:8081/publishers/\\d+",
+		func(req *http.Request) (*http.Response, error) {
+			publisherID := req.URL.Path[len("/publishers/"):]
+			resource, ok := allResources[publisherID]
+			if !ok {
+				return httpmock.NewStringResponse(404, ""), nil
+			}
+			resourceMap, ok := resource.(map[string]interface{})
+			if !ok {
+				return httpmock.NewStringResponse(500, ""), nil
+			}
+			resourceMap["path"] = fmt.Sprintf("/publishers/%s", publisherID)
+			jsonResource, err := json.Marshal(resource)
+			bookCounter += 1
+			if err != nil {
+				return httpmock.NewStringResponse(500, ""), nil
+			}
+			return httpmock.NewStringResponse(200, string(jsonResource)), nil
+		},
+	)
+
+	httpmock.RegisterResponder("PATCH", "=~^http://localhost:8081/publishers/\\d+",
+		func(req *http.Request) (*http.Response, error) {
+			publisherID := req.URL.Path[len("/publishers/"):]
+			_, ok := allResources[publisherID]
+			if !ok {
+				return httpmock.NewStringResponse(404, ""), nil
+			}
+
+			var requestBody map[string]interface{}
+			err := json.NewDecoder(req.Body).Decode(&requestBody)
+			if err != nil {
+				return httpmock.NewStringResponse(400, ""), nil
+			}
+			allResources[publisherID] = requestBody
+			requestBody["path"] = fmt.Sprintf("/publishers/%s", publisherID)
+			jsonResource, err := json.Marshal(requestBody)
+			if err != nil {
+				return httpmock.NewStringResponse(500, ""), nil
+			}
+			return httpmock.NewStringResponse(200, string(jsonResource)), nil
+		},
+	)
+
+	httpmock.RegisterResponder("DELETE", "=~^http://localhost:8081/publishers/\\d+",
+		func(req *http.Request) (*http.Response, error) {
+			publisherID := req.URL.Path[len("/publishers/"):]
+			_, ok := allResources[publisherID]
+			if !ok {
+				return httpmock.NewStringResponse(404, ""), nil
+			}
+
+			delete(allResources, publisherID)
+
+			return httpmock.NewStringResponse(200, ""), nil
+		},
+	)
+
 }

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -15,13 +15,13 @@ import (
 )
 
 // The full schema - includes all fields from body + parameters for parents.
-func FullSchema(r *api.Resource, o *openapi.OpenAPI) (map[string]tfschema.Attribute, error) {
+func FullSchema(r *api.Resource) (map[string]tfschema.Attribute, error) {
 	attributes, err := SchemaAttributes(*r.Schema)
 	if err != nil {
 		return nil, err
 	}
 
-	parameterAttributes, err := ParameterAttributes(r, o)
+	parameterAttributes, err := ParameterAttributes(r)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func SchemaAttributes(schema openapi.Schema) (map[string]tfschema.Attribute, err
 }
 
 // Attributes coming from parents.
-func ParameterAttributes(r *api.Resource, o *openapi.OpenAPI) (map[string]tfschema.Attribute, error) {
+func ParameterAttributes(r *api.Resource) (map[string]tfschema.Attribute, error) {
 	m := make(map[string]tfschema.Attribute)
 
 	// Do not go through last element, since that's the resource itself.

--- a/internal/provider/resource_schema.go
+++ b/internal/provider/resource_schema.go
@@ -43,6 +43,7 @@ func SchemaAttributes(schema openapi.Schema) (map[string]tfschema.Attribute, err
 		}
 		m[ToSnakeCase(name)] = a
 	}
+
 	m["id"] = tfschema.StringAttribute{
 		Computed: true,
 	}

--- a/internal/provider/testdata/oas.yaml
+++ b/internal/provider/testdata/oas.yaml
@@ -1,934 +1,951 @@
 {
-  'openapi': '3.1.0',
-  'servers': [{ 'url': 'http://localhost:8081' }],
-  'info':
+  "openapi": "3.1.0",
+  "servers": [
     {
-      'title': 'bookstore.example.com',
-      'description': 'An API for bookstore.example.com',
-      'version': 'version not set',
+      "url": "http://localhost:8081"
+    }
+  ],
+  "info": {
+    "title": "bookstore.example.com",
+    "description": "An API for bookstore.example.com",
+    "version": "version not set"
+  },
+  "paths": {
+    "/isbns": {
+      "get": {
+        "description": "List method for isbn",
+        "operationId": "ListIsbn",
+        "parameters": [
+          {
+            "name": "max_page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/isbn"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create method for isbn",
+        "operationId": "CreateIsbn",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/isbn"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/isbn"
+              }
+            }
+          },
+          "required": true
+        }
+      }
     },
-  'paths':
-    {
-      '/isbns':
-        {
-          'get':
-            {
-              'description': 'List method for isbn',
-              'operationId': 'ListIsbn',
-              'parameters':
-                [
-                  {
-                    'name': 'max_page_size',
-                    'in': 'query',
-                    'schema': { 'type': 'integer' },
-                  },
-                  {
-                    'name': 'page_token',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    {
-                                      'results':
-                                        {
-                                          'type': 'array',
-                                          'items':
-                                            {
-                                              '$ref': '#/components/schemas/isbn',
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'post':
-            {
-              'description': 'Create method for isbn',
-              'operationId': 'CreateIsbn',
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/isbn' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        { 'schema': { '$ref': '#/components/schemas/isbn' } },
-                    },
-                  'required': true,
-                },
-            },
-        },
-      '/isbns/{isbn}':
-        {
-          'get':
-            {
-              'description': 'Get method for isbn',
-              'operationId': 'GetIsbn',
-              'parameters':
-                [
-                  {
-                    'name': 'isbn',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/isbn' },
-                            },
-                        },
-                    },
-                },
-            },
-        },
-      '/publishers':
-        {
-          'get':
-            {
-              'description': 'List method for publisher',
-              'operationId': 'ListPublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'max_page_size',
-                    'in': 'query',
-                    'schema': { 'type': 'integer' },
-                  },
-                  {
-                    'name': 'page_token',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    {
-                                      'results':
-                                        {
-                                          'type': 'array',
-                                          'items':
-                                            {
-                                              '$ref': '#/components/schemas/publisher',
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'post':
-            {
-              'description': 'Create method for publisher',
-              'operationId': 'CreatePublisher',
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/publisher' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        {
-                          'schema':
-                            { '$ref': '#/components/schemas/publisher' },
-                        },
-                    },
-                  'required': true,
-                },
-            },
-        },
-      '/publishers/{publisher}':
-        {
-          'get':
-            {
-              'description': 'Get method for publisher',
-              'operationId': 'GetPublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/publisher' },
-                            },
-                        },
-                    },
-                },
-            },
-          'patch':
-            {
-              'description': 'Update method for publisher',
-              'operationId': 'UpdatePublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/publisher' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        {
-                          'schema':
-                            { '$ref': '#/components/schemas/publisher' },
-                        },
-                    },
-                  'required': true,
-                },
-            },
-          'put':
-            {
-              'description': 'Apply method for publisher',
-              'operationId': 'ApplyPublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/publisher' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        {
-                          'schema':
-                            { '$ref': '#/components/schemas/publisher' },
-                        },
-                    },
-                  'required': true,
-                },
-            },
-          'delete':
-            {
-              'description': 'Delete method for publisher',
-              'operationId': 'DeletePublisher',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'force',
-                    'in': 'query',
-                    'schema': { 'type': 'boolean' },
-                  },
-                ],
-              'responses':
-                {
-                  '204':
-                    {
-                      'description': 'Successful response',
-                      'content': { 'application/json': { 'schema': {} } },
-                    },
-                },
-            },
-        },
-      '/publishers/{publisher}/books':
-        {
-          'get':
-            {
-              'description': 'List method for book',
-              'operationId': 'ListBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'max_page_size',
-                    'in': 'query',
-                    'schema': { 'type': 'integer' },
-                  },
-                  {
-                    'name': 'page_token',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    {
-                                      'results':
-                                        {
-                                          'type': 'array',
-                                          'items':
-                                            {
-                                              '$ref': '#/components/schemas/book',
-                                            },
-                                        },
-                                      'unreachable':
-                                        {
-                                          'type': 'array',
-                                          'items': { 'type': 'string' },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'post':
-            {
-              'description': 'Create method for book',
-              'operationId': 'CreateBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        { 'schema': { '$ref': '#/components/schemas/book' } },
-                    },
-                  'required': true,
-                },
-            },
-        },
-      '/publishers/{publisher}/books/{book}':
-        {
-          'get':
-            {
-              'description': 'Get method for book',
-              'operationId': 'GetBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
-            },
-          'patch':
-            {
-              'description': 'Update method for book',
-              'operationId': 'UpdateBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        { 'schema': { '$ref': '#/components/schemas/book' } },
-                    },
-                  'required': true,
-                },
-            },
-          'put':
-            {
-              'description': 'Apply method for book',
-              'operationId': 'ApplyBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        { 'schema': { '$ref': '#/components/schemas/book' } },
-                    },
-                  'required': true,
-                },
-            },
-          'delete':
-            {
-              'description': 'Delete method for book',
-              'operationId': 'DeleteBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'force',
-                    'in': 'query',
-                    'schema': { 'type': 'boolean' },
-                  },
-                ],
-              'responses':
-                {
-                  '204':
-                    {
-                      'description': 'Successful response',
-                      'content': { 'application/json': { 'schema': {} } },
-                    },
-                },
-            },
-        },
-      '/publishers/{publisher}/books/{book}/editions':
-        {
-          'get':
-            {
-              'description': 'List method for book-edition',
-              'operationId': 'ListBookEdition',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'max_page_size',
-                    'in': 'query',
-                    'schema': { 'type': 'integer' },
-                  },
-                  {
-                    'name': 'page_token',
-                    'in': 'query',
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  'type': 'object',
-                                  'properties':
-                                    {
-                                      'results':
-                                        {
-                                          'type': 'array',
-                                          'items':
-                                            {
-                                              '$ref': '#/components/schemas/book-edition',
-                                            },
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'post':
-            {
-              'description': 'Create method for book-edition',
-              'operationId': 'CreateBookEdition',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  '$ref': '#/components/schemas/book-edition',
-                                },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content':
-                    {
-                      'application/json':
-                        {
-                          'schema':
-                            { '$ref': '#/components/schemas/book-edition' },
-                        },
-                    },
-                  'required': true,
-                },
-            },
-        },
-      '/publishers/{publisher}/books/{book}/editions/{book-edition}':
-        {
-          'get':
-            {
-              'description': 'Get method for book-edition',
-              'operationId': 'GetBookEdition',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book-edition',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                {
-                                  '$ref': '#/components/schemas/book-edition',
-                                },
-                            },
-                        },
-                    },
-                },
-            },
-          'delete':
-            {
-              'description': 'Delete method for book-edition',
-              'operationId': 'DeleteBookEdition',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book-edition',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '204':
-                    {
-                      'description': 'Successful response',
-                      'content': { 'application/json': { 'schema': {} } },
-                    },
-                },
-            },
-        },
-      '/publishers/{publisher}/books/{book}:archive':
-        {
-          'post':
-            {
-              'description': 'Custom method archive for book',
-              'operationId': ':ArchiveBook',
-              'parameters':
-                [
-                  {
-                    'name': 'publisher',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                  {
-                    'name': 'book',
-                    'in': 'path',
-                    'required': true,
-                    'schema': { 'type': 'string' },
-                  },
-                ],
-              'responses':
-                {
-                  '200':
-                    {
-                      'description': 'Successful response',
-                      'content':
-                        {
-                          'application/json':
-                            {
-                              'schema':
-                                { '$ref': '#/components/schemas/book' },
-                            },
-                        },
-                    },
-                },
-              'requestBody':
-                {
-                  'content': { 'application/json': { 'schema': {} } },
-                  'required': true,
-                },
-            },
-        },
+    "/isbns/{isbn}": {
+      "get": {
+        "description": "Get method for isbn",
+        "operationId": "GetIsbn",
+        "parameters": [
+          {
+            "name": "isbn",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/isbn"
+                }
+              }
+            }
+          }
+        }
+      }
     },
-  'components':
-    {
-      'schemas':
-        {
-          'book':
-            {
-              'type': 'object',
-              'properties':
-                {
-                  'author':
-                    {
-                      'type': 'array',
-                      'items':
-                        {
-                          'type': 'object',
-                          'properties':
-                            {
-                              'firstName': { 'type': 'string' },
-                              'lastName': { 'type': 'string' },
-                            },
-                          'x-aep-field-numbers':
-                            { '1': 'firstName', '2': 'lastName' },
-                        },
-                    },
-                  'edition': { 'type': 'integer', 'format': 'int32' },
-                  'isbn': { 'type': 'array', 'items': { 'type': 'string' } },
-                  'path': { 'type': 'string', 'readOnly': true },
-                  'price': { 'type': 'number', 'format': 'float' },
-                  'published': { 'type': 'boolean' },
-                },
-              'x-aep-resource':
-                {
-                  'singular': 'book',
-                  'plural': 'books',
-                  'patterns': ['publishers/{publisher}/books/{book}'],
-                  'parents': ['publisher'],
-                },
-              'x-aep-field-numbers':
-                {
-                  '0': 'author',
-                  '1': 'isbn',
-                  '10018': 'path',
-                  '2': 'price',
-                  '3': 'published',
-                  '4': 'edition',
-                },
-              'required': ['isbn', 'price', 'published'],
-            },
-          'book-edition':
-            {
-              'type': 'object',
-              'properties':
-                {
-                  'displayname': { 'type': 'string' },
-                  'path': { 'type': 'string', 'readOnly': true },
-                },
-              'x-aep-resource':
-                {
-                  'singular': 'book-edition',
-                  'plural': 'book-editions',
-                  'patterns':
-                    [
-                      'publishers/{publisher}/books/{book}/editions/{book-edition}',
-                    ],
-                  'parents': ['book'],
-                },
-              'x-aep-field-numbers': { '1': 'displayname', '10018': 'path' },
-              'required': ['displayname'],
-            },
-          'isbn':
-            {
-              'type': 'object',
-              'properties': { 'path': { 'type': 'string', 'readOnly': true } },
-              'x-aep-resource':
-                {
-                  'singular': 'isbn',
-                  'plural': 'isbns',
-                  'patterns': ['isbns/{isbn}'],
-                },
-              'x-aep-field-numbers': { '10018': 'path' },
-            },
-          'publisher':
-            {
-              'type': 'object',
-              'properties':
-                {
-                  'description': { 'type': 'string' },
-                  'path': { 'type': 'string', 'readOnly': true },
-                },
-              'x-aep-resource':
-                {
-                  'singular': 'publisher',
-                  'plural': 'publishers',
-                  'patterns': ['publishers/{publisher}'],
-                },
-              'x-aep-field-numbers': { '1': 'description', '10018': 'path' },
-            },
+    "/publishers": {
+      "get": {
+        "description": "List method for publisher",
+        "operationId": "ListPublisher",
+        "parameters": [
+          {
+            "name": "max_page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/publisher"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create method for publisher",
+        "operationId": "CreatePublisher",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publisher"
+                }
+              }
+            }
+          }
         },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publisher"
+              }
+            }
+          },
+          "required": true
+        }
+      }
     },
+    "/publishers/{publisher}": {
+      "get": {
+        "description": "Get method for publisher",
+        "operationId": "GetPublisher",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publisher"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update method for publisher",
+        "operationId": "UpdatePublisher",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publisher"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publisher"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "put": {
+        "description": "Apply method for publisher",
+        "operationId": "ApplyPublisher",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/publisher"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/publisher"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "description": "Delete method for publisher",
+        "operationId": "DeletePublisher",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/publishers/{publisher}/books": {
+      "get": {
+        "description": "List method for book",
+        "operationId": "ListBook",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "max_page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/book"
+                      }
+                    },
+                    "unreachable": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create method for book",
+        "operationId": "CreateBook",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/book"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/publishers/{publisher}/books/{book}": {
+      "get": {
+        "description": "Get method for book",
+        "operationId": "GetBook",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "description": "Update method for book",
+        "operationId": "UpdateBook",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/book"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "put": {
+        "description": "Apply method for book",
+        "operationId": "ApplyBook",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/book"
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "description": "Delete method for book",
+        "operationId": "DeleteBook",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/publishers/{publisher}/books/{book}/editions": {
+      "get": {
+        "description": "List method for book-edition",
+        "operationId": "ListBookEdition",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "max_page_size",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/book-edition"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Create method for book-edition",
+        "operationId": "CreateBookEdition",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book-edition"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/book-edition"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/publishers/{publisher}/books/{book}/editions/{book-edition}": {
+      "get": {
+        "description": "Get method for book-edition",
+        "operationId": "GetBookEdition",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book-edition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book-edition"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "Delete method for book-edition",
+        "operationId": "DeleteBookEdition",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book-edition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/publishers/{publisher}/books/{book}:archive": {
+      "post": {
+        "description": "Custom method archive for book",
+        "operationId": ":ArchiveBook",
+        "parameters": [
+          {
+            "name": "publisher",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "book",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/book"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "book": {
+        "type": "object",
+        "properties": {
+          "author": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "firstName": {
+                  "type": "string"
+                },
+                "lastName": {
+                  "type": "string"
+                }
+              },
+              "x-aep-field-numbers": {
+                "1": "firstName",
+                "2": "lastName"
+              }
+            }
+          },
+          "edition": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isbn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "path": {
+            "type": "string",
+            "readOnly": true
+          },
+          "price": {
+            "type": "number",
+            "format": "float"
+          },
+          "published": {
+            "type": "boolean"
+          }
+        },
+        "x-aep-resource": {
+          "singular": "book",
+          "plural": "books",
+          "patterns": [
+            "publishers/{publisher}/books/{book}"
+          ],
+          "parents": [
+            "publisher"
+          ]
+        },
+        "x-aep-field-numbers": {
+          "0": "author",
+          "1": "isbn",
+          "10018": "path",
+          "2": "price",
+          "3": "published",
+          "4": "edition"
+        },
+        "required": [
+          "isbn",
+          "price",
+          "published"
+        ]
+      },
+      "book-edition": {
+        "type": "object",
+        "properties": {
+          "displayname": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "x-aep-resource": {
+          "singular": "book-edition",
+          "plural": "book-editions",
+          "patterns": [
+            "publishers/{publisher}/books/{book}/editions/{book-edition}"
+          ],
+          "parents": [
+            "book"
+          ]
+        },
+        "x-aep-field-numbers": {
+          "1": "displayname",
+          "10018": "path"
+        },
+        "required": [
+          "displayname"
+        ]
+      },
+      "isbn": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "x-aep-resource": {
+          "singular": "isbn",
+          "plural": "isbns",
+          "patterns": [
+            "isbns/{isbn}"
+          ]
+        },
+        "x-aep-field-numbers": {
+          "10018": "path"
+        }
+      },
+      "publisher": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "x-aep-resource": {
+          "singular": "publisher",
+          "plural": "publishers",
+          "patterns": [
+            "publishers/{publisher}"
+          ]
+        },
+        "x-aep-field-numbers": {
+          "1": "description",
+          "10018": "path"
+        }
+      }
+    }
+  }
 }

--- a/internal/provider/testdata/oas.yaml
+++ b/internal/provider/testdata/oas.yaml
@@ -844,8 +844,7 @@
             "readOnly": true
           },
           "price": {
-            "type": "number",
-            "format": "float"
+            "type": "string"
           },
           "published": {
             "type": "boolean"

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"net/http"
 
 	"github.com/aep-dev/aep-lib-go/pkg/openapi"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
@@ -47,7 +48,7 @@ func main() {
 		log.Fatal(err.Error())
 	}
 
-	err = providerserver.Serve(context.Background(), provider.New(version, gen, oas), opts)
+	err = providerserver.Serve(context.Background(), provider.New(version, gen, oas, http.DefaultClient), opts)
 
 	if err != nil {
 		log.Fatal(err.Error())


### PR DESCRIPTION
This creates a mock server for books / publishers and then runs the Terraform provider (with sample OpenAPI spec) against that provider.

Since AEP doesn't run a service, we should use mock services as a way to ensure that the auto-generated provider is working as intended.