### PR TITLE
ID Fix

### DIFF
--- a/internal/provider/data/resource_schema.go
+++ b/internal/provider/data/resource_schema.go
@@ -189,6 +189,7 @@ func schemaAttribute(ctx context.Context, prop *openapi.Schema, name string, req
 	// GoogleProtobufValue is a type based on its name.
 	// It's just a string that stands in for arbitrary JSON.
 	if prop.Ref == "#/components/schemas/GoogleProtobufValue" {
+		m.Type = STRING
 		m.Attribute = tfschema.StringAttribute{
 			MarkdownDescription: prop.Description,
 			Computed:            prop.ReadOnly,


### PR DESCRIPTION
'id' is a special primary key field in Terraform. For AEPs, it's really only used for user-generated IDs. 

We have to do some special logic to reconcile this. We want it to be the path field (typically) unless it's a user-generated field or unless it'll otherwise break state.