### PR TITLE
weird edge case for objects

### DIFF
--- a/internal/provider/body.go
+++ b/internal/provider/body.go
@@ -95,7 +95,8 @@ func State(ctx context.Context, resp map[string]interface{}, plan *data.Resource
 
 	result["id"] = id
 
-	err = data.FromJSON(result, plan)
+	// TODO: This shouldn't take in plan twice.
+	err = data.FromJSON(result, plan, plan)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The Roblox API returns an empty object when state is unset.

I know empty object != unset, but I'm putting this here for now. This can be changed later on.