### PR TITLE
Model the provider as a library

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - run: go mod download
-      - run: go build -v .
+      - run: make build
       - name: Run linters
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v6.1.1
         with:

--- a/internal/provider/data/resource_schema_test.go
+++ b/internal/provider/data/resource_schema_test.go
@@ -8,14 +8,16 @@ import (
 	"github.com/aep-dev/aep-lib-go/pkg/openapi"
 	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	dsschema "github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	tfschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func TestSchemaAttributes(t *testing.T) {
 	tests := map[string]struct {
-		schema openapi.Schema
-		want   *ResourceSchema
+		schema   openapi.Schema
+		resource *api.Resource
+		want     *ResourceSchema
 	}{
 		"simple": {
 			schema: openapi.Schema{
@@ -30,6 +32,12 @@ func TestSchemaAttributes(t *testing.T) {
 					},
 				},
 			},
+			resource: &api.Resource{
+				CreateMethod: &api.CreateMethod{
+					SupportsUserSettableCreate: true,
+				},
+				PatternElems: []string{},
+			},
 			want: &ResourceSchema{
 				Attributes: map[string]*ResourceAttribute{
 					"foo": {
@@ -41,6 +49,10 @@ func TestSchemaAttributes(t *testing.T) {
 							MarkdownDescription: "foo description",
 							Optional:            true,
 						},
+						DatasourceAttribute: dsschema.StringAttribute{
+							MarkdownDescription: "foo description",
+							Computed:            true,
+						},
 					},
 					"id": {
 						TerraformName: "id",
@@ -49,6 +61,10 @@ func TestSchemaAttributes(t *testing.T) {
 						Type:          STRING,
 						Attribute: tfschema.StringAttribute{
 							Optional:            true,
+							MarkdownDescription: "The id of the resource",
+						},
+						DatasourceAttribute: dsschema.StringAttribute{
+							Computed:            true,
 							MarkdownDescription: "The id of the resource",
 						},
 					},
@@ -65,6 +81,12 @@ func TestSchemaAttributes(t *testing.T) {
 				},
 				Required: []string{"foo"},
 			},
+			resource: &api.Resource{
+				CreateMethod: &api.CreateMethod{
+					SupportsUserSettableCreate: false,
+				},
+				PatternElems: []string{},
+			},
 			want: &ResourceSchema{
 				Attributes: map[string]*ResourceAttribute{
 					"foo": {
@@ -76,6 +98,10 @@ func TestSchemaAttributes(t *testing.T) {
 							MarkdownDescription: "foo description",
 							Required:            true,
 						},
+						DatasourceAttribute: dsschema.StringAttribute{
+							MarkdownDescription: "foo description",
+							Computed:            true,
+						},
 					},
 					"id": {
 						TerraformName: "id",
@@ -83,6 +109,10 @@ func TestSchemaAttributes(t *testing.T) {
 						Parameter:     true,
 						Type:          STRING,
 						Attribute: tfschema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The id of the resource.",
+						},
+						DatasourceAttribute: dsschema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "The id of the resource.",
 						},
@@ -101,9 +131,14 @@ func TestSchemaAttributes(t *testing.T) {
 								Description: "bar description",
 							},
 						},
-						Required: []string{"bar"},
 					},
 				},
+			},
+			resource: &api.Resource{
+				CreateMethod: &api.CreateMethod{
+					SupportsUserSettableCreate: false,
+				},
+				PatternElems: []string{},
 			},
 			want: &ResourceSchema{
 				Attributes: map[string]*ResourceAttribute{
@@ -113,24 +148,36 @@ func TestSchemaAttributes(t *testing.T) {
 						Parameter:     false,
 						Type:          OBJECT,
 						Attribute: tfschema.SingleNestedAttribute{
+							Optional: true,
 							Attributes: map[string]tfschema.Attribute{
 								"bar": tfschema.StringAttribute{
+									Optional:            true,
 									MarkdownDescription: "bar description",
-									Required:            true,
-									Optional:            false,
 								},
 							},
-							MarkdownDescription: "",
-							Optional:            true,
+						},
+						DatasourceAttribute: dsschema.SingleNestedAttribute{
+							Computed: true,
+							Attributes: map[string]dsschema.Attribute{
+								"bar": dsschema.StringAttribute{
+									Computed:            true,
+									MarkdownDescription: "bar description",
+								},
+							},
 						},
 						NestedAttributes: map[string]*ResourceAttribute{
 							"bar": {
 								TerraformName: "bar",
 								JSONName:      "bar",
+								Parameter:     false,
 								Type:          STRING,
 								Attribute: tfschema.StringAttribute{
-									Required:            true,
 									MarkdownDescription: "bar description",
+									Optional:            true,
+								},
+								DatasourceAttribute: dsschema.StringAttribute{
+									MarkdownDescription: "bar description",
+									Computed:            true,
 								},
 							},
 						},
@@ -141,6 +188,10 @@ func TestSchemaAttributes(t *testing.T) {
 						Parameter:     true,
 						Type:          STRING,
 						Attribute: tfschema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The id of the resource.",
+						},
+						DatasourceAttribute: dsschema.StringAttribute{
 							Computed:            true,
 							MarkdownDescription: "The id of the resource.",
 						},
@@ -159,6 +210,12 @@ func TestSchemaAttributes(t *testing.T) {
 					},
 				},
 			},
+			resource: &api.Resource{
+				CreateMethod: &api.CreateMethod{
+					SupportsUserSettableCreate: false,
+				},
+				PatternElems: []string{},
+			},
 			want: &ResourceSchema{
 				Attributes: map[string]*ResourceAttribute{
 					"foo": {
@@ -168,9 +225,14 @@ func TestSchemaAttributes(t *testing.T) {
 						Type:          ARRAY,
 						ListItemType:  STRING,
 						Attribute: tfschema.ListAttribute{
-							ElementType:         types.StringType,
 							MarkdownDescription: "",
 							Optional:            true,
+							ElementType:         types.StringType,
+						},
+						DatasourceAttribute: dsschema.ListAttribute{
+							MarkdownDescription: "",
+							Computed:            true,
+							ElementType:         types.StringType,
 						},
 					},
 					"id": {
@@ -182,6 +244,10 @@ func TestSchemaAttributes(t *testing.T) {
 							Computed:            true,
 							MarkdownDescription: "The id of the resource.",
 						},
+						DatasourceAttribute: dsschema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The id of the resource.",
+						},
 					},
 				},
 			},
@@ -190,7 +256,8 @@ func TestSchemaAttributes(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := NewResourceSchema(context.TODO(), &api.Resource{Schema: &tt.schema, PatternElems: make([]string, 0)}, &openapi.OpenAPI{})
+			tt.resource.Schema = &tt.schema
+			got, err := NewResourceSchema(context.TODO(), tt.resource, &openapi.OpenAPI{})
 			if err != nil {
 				t.Errorf("SchemaAttributes() error = %v", err)
 				return

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -1,0 +1,48 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/aep-dev/aep-lib-go/pkg/client"
+	"github.com/aep-dev/terraform-provider-aep/config"
+	internalprovider "github.com/aep-dev/terraform-provider-aep/internal/provider"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	tfprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+type Provider struct {
+	config *config.ProviderConfig
+	client *client.Client
+
+	provider tfprovider.Provider
+}
+
+func NewProvider(config *config.ProviderConfig, client *client.Client, version string) (*Provider, error) {
+	gen, err := internalprovider.CreateGeneratedProviderData(context.Background(), config.OpenAPIPath(), config.PathPrefix())
+	if err != nil {
+		return nil, err
+	}
+
+	return &Provider{
+		config:   config,
+		client:   client,
+		provider: internalprovider.New(version, gen, client, *config)(),
+	}, nil
+}
+
+func (p *Provider) Provider() tfprovider.Provider {
+	return p.provider
+}
+
+func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
+	return p.provider.(interface {
+		Resources(context.Context) []func() resource.Resource
+	}).Resources(ctx)
+}
+
+func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
+	return p.provider.(interface {
+		DataSources(context.Context) []func() datasource.DataSource
+	}).DataSources(ctx)
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -36,13 +36,19 @@ func (p *Provider) Provider() tfprovider.Provider {
 }
 
 func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
-	return p.provider.(interface {
+	if provider, ok := p.provider.(interface {
 		Resources(context.Context) []func() resource.Resource
-	}).Resources(ctx)
+	}); ok {
+		return provider.Resources(ctx)
+	}
+	return nil
 }
 
 func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return p.provider.(interface {
+	if provider, ok := p.provider.(interface {
 		DataSources(context.Context) []func() datasource.DataSource
-	}).DataSources(ctx)
+	}); ok {
+		return provider.DataSources(ctx)
+	}
+	return nil
 }


### PR DESCRIPTION
I've wrapped the existing Terraform provider as a library, so it can be used easier. There's an example file showing how one would import this library to create their own provider.

Bonus: since it's a library, we can expose out resources + data sources as methods. That way, it's really easy for somebody to import our library and extend their current Terraform provider with AEP-based resources.

There's also some test fixes, because apparently they were broken.