### PR TITLE
Provider should be runnable standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,44 @@
 
 The AEP Terraform Provider generates a run-time Terraform provider for use with AEP-compliant APIs. This allows API developers who have created AEP-compliant APIs to create or extend a Terraform provider with new resources with near-zero additional development time.
 
-For more information about the AEP project, visit [aep.dev](https://aep.dev)
+For more information about the AEP project, visit [aep.dev](https://aep.dev).
 
 ## Requirements
 
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.22
+- [Go](https://golang.org/doc/install) >= 1.22 (only needed for building from source or library usage)
 
-## Building The Provider
+## Using the Provider
 
-This repository is a library that provides both a Terraform provider and Terraform resources. Please see `examples/main.go` to see how to create a new provider.
+### Installation
 
-## Using the provider
-
-This provider automatically generates its schema based off the AEP-compliant OpenAPI spec.
-
-`terraform providers schema -json` will show the current schema.
-
-## Authentication
-
-The provider supports setting custom headers for API requests through the provider configuration. This is useful for setting authentication tokens, API keys, or other required headers.
-
-Example configuration in `provider.tf`:
+Add the provider to your Terraform configuration:
 
 ```hcl
-provider "scaffolding" {
+terraform {
+  required_providers {
+    aep = {
+      source = "aep-dev/aep"
+    }
+  }
+}
+```
+
+### Configuration
+
+The provider reads your AEP-compliant OpenAPI spec at startup and dynamically generates Terraform resources for each API resource it finds.
+
+#### Environment Variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `AEP_OPENAPI` | Yes | URL or file path to your OpenAPI spec (e.g. `http://localhost:8081/openapi.json`) |
+| `AEP_PATH_PREFIX` | No | A path prefix prepended to all API methods. Use this if all your OpenAPI paths share a common prefix (e.g. `/cloud/v2`). |
+
+#### Provider Block
+
+```hcl
+provider "aep" {
   headers = {
     "Authorization" = "Bearer your-token-here"
     "X-API-Key"     = "your-api-key"
@@ -34,21 +47,84 @@ provider "scaffolding" {
 }
 ```
 
-These headers will be sent with every request made by the provider to the API.
+The `headers` attribute sets custom HTTP headers sent with every API request. This is the primary way to configure authentication.
 
+### Resources and Data Sources
 
-## Developing the Provider Locally
+The provider automatically generates its schema from the OpenAPI spec. Run `terraform providers schema -json` to see the available resources and their attributes.
 
-`go install` will install the provider to your `$GOPATH/bin` folder.
+Resources are named `aep_<resource>`, and collection data sources are named `aep_<resource>s`.
 
-You'll need a CLI config file with the following code to allow the Terraform CLI to point to your local provider
+#### Example
 
+Given an OpenAPI spec that defines a `publishers` resource with a nested `books` resource:
+
+```hcl
+resource "aep_publisher" "example" {
+  description = "Example publisher"
+}
+
+resource "aep_book" "example" {
+  publisher_id = aep_publisher.example.id
+  isbn         = "978-0-13-468599-1"
+  title        = "The Go Programming Language"
+}
 ```
+
+## Using as a Library
+
+This provider can also be embedded into your own Terraform provider binary. This is useful if you want to customize the provider name, set a fixed OpenAPI path, or bundle it with additional resources.
+
+See `examples/main.go` for a complete example. The key steps are:
+
+```go
+package main
+
+import (
+    "github.com/aep-dev/terraform-provider-aep/config"
+    "github.com/aep-dev/terraform-provider-aep/provider"
+)
+
+func main() {
+    cfg := config.NewProviderConfigWithOptions(
+        "http://localhost:8081/openapi.json",          // openAPIPath
+        "",                                            // pathPrefix
+        "registry.terraform.io/your-org/your-provider", // registryURL
+        "yourprovider",                                // providerPrefix
+    )
+
+    c := client.NewClient(http.DefaultClient)
+    p, err := provider.NewProvider(&cfg, c, "1.0.0")
+    // ... serve with providerserver.Serve()
+}
+```
+
+When used as a library, resources will be named `yourprovider_<resource>` based on the prefix you choose.
+
+## Developing the Provider
+
+```sh
+# Build
+go build -v ./...
+
+# Install locally
+go install -v ./...
+
+# Run tests
+go test -v -cover -timeout=120s -parallel=10 ./...
+
+# Run acceptance tests
+TF_ACC=1 go test -v -cover -timeout 120m ./...
+```
+
+To point the Terraform CLI at your local build, create a CLI config file:
+
+```hcl
 provider_installation {
   dev_overrides {
-    "hashicorp/scaffolding" = "/home/go/bin"
+    "aep-dev/aep" = "/your/gopath/bin"
   }
 }
 ```
 
-Set `TF_CLI_CONFIG_FILE` to the path of that config file.
+Then set `TF_CLI_CONFIG_FILE` to the path of that file.

--- a/config/config.go
+++ b/config/config.go
@@ -2,11 +2,11 @@ package config
 
 import "os"
 
-// Only change these values.
+// Only change these values when using this package as a library.
 
 // The URI where your OpenAPI spec lives.
 // This will default to AEP_OPENAPI if empty.
-const OpenAPIPath = "http://localhost:8081/openapi.json"
+const OpenAPIPath = ""
 
 // A Path prefix.
 // This is a value that will prepend all of your OpenAPI methods
@@ -16,11 +16,11 @@ const PathPrefix = ""
 
 // The name of your provider.
 // All resources will have the prefix `prefix_resource`.
-const ProviderPrefix = "scaffolding"
+const ProviderPrefix = "aep"
 
 // The URL for your provider.
 // This should be set once you have a listing in the Terraform Registry.
-const RegistryURL = "registry.terraform.io/hashicorp/scaffolding"
+const RegistryURL = "registry.terraform.io/aep-dev/aep"
 
 // Do not change anything below here!
 
@@ -55,8 +55,9 @@ func NewProviderConfig() ProviderConfig {
 	}
 }
 
-// Only for testing!
-func NewProviderConfigForTesting(openAPI string, pathPrefix string, registryUrl string, providerPrefix string) ProviderConfig {
+// NewProviderConfigWithOptions creates a ProviderConfig with explicit values.
+// Use this when embedding the provider as a library.
+func NewProviderConfigWithOptions(openAPI string, pathPrefix string, registryUrl string, providerPrefix string) ProviderConfig {
 	return ProviderConfig{
 		openAPIPath:    openAPI,
 		pathPrefix:     pathPrefix,

--- a/internal/provider/integration_test.go
+++ b/internal/provider/integration_test.go
@@ -24,7 +24,7 @@ func aepbaseProviderFactory() map[string]func() (tfprotov6.ProviderServer, error
 				return nil, fmt.Errorf("unable to create generated data from %s: %v", openAPIURL, err)
 			}
 			httpClient := client.NewClient(&http.Client{})
-			providerConfig := config.NewProviderConfigForTesting(openAPIURL, "", "", "scaffolding")
+			providerConfig := config.NewProviderConfigWithOptions(openAPIURL, "", "", "scaffolding")
 			return providerserver.NewProtocol6WithError(New("test", gen, httpClient, providerConfig)())()
 		},
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -41,7 +41,7 @@ type ScaffoldingProviderModel struct {
 }
 
 func (p *ScaffoldingProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
-	resp.TypeName = "scaffolding"
+	resp.TypeName = p.config.ProviderPrefix
 	resp.Version = p.version
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -29,7 +29,7 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 			return nil, fmt.Errorf("unable to create generated data %v", err)
 		}
 		mockClient := client.NewClient(&http.Client{})
-		providerConfig := config.NewProviderConfigForTesting("http://localhost:8081/openapi.json", "", "", "scaffolding")
+		providerConfig := config.NewProviderConfigWithOptions("http://localhost:8081/openapi.json", "", "", "scaffolding")
 		return providerserver.NewProtocol6WithError(New("test", gen, mockClient, providerConfig)())()
 	},
 }
@@ -42,7 +42,7 @@ var testAccProtoV6ProviderFactoriesWithRoblox = map[string]func() (tfprotov6.Pro
 			return nil, fmt.Errorf("unable to create generated data %v", err)
 		}
 		mockClient := client.NewClient(&http.Client{})
-		providerConfig := config.NewProviderConfigForTesting("http://localhost:8081/openapi.json", "", "", "scaffolding")
+		providerConfig := config.NewProviderConfigWithOptions("http://localhost:8081/openapi.json", "", "", "scaffolding")
 		return providerserver.NewProtocol6WithError(New("test", gen, mockClient, providerConfig)())()
 	},
 }

--- a/main.go
+++ b/main.go
@@ -1,6 +1,3 @@
-// Copyright (c) HashiCorp, Inc.
-// SPDX-License-Identifier: MPL-2.0
-
 package main
 
 import (
@@ -18,12 +15,7 @@ import (
 )
 
 var (
-	// these will be set by the goreleaser configuration
-	// to appropriate values for the compiled binary.
 	version string = "dev"
-
-	// goreleaser can pass other information to the main package, such as the specific commit
-	// https://goreleaser.com/cookbooks/using-main.version/
 )
 
 func main() {
@@ -32,14 +24,7 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	// Setup config and HTTP Client.
-	// When using as a library, provide your own values here.
-	cfg := config.NewProviderConfigWithOptions(
-		"http://localhost:8081/openapi.json", // openAPIPath
-		"",                                   // pathPrefix
-		"registry.terraform.io/hashicorp/scaffolding", // registryURL
-		"scaffolding", // providerPrefix
-	)
+	cfg := config.NewProviderConfig()
 	c := client.NewClient(http.DefaultClient)
 
 	c.RequestLoggingFunction = func(ctx context.Context, req *http.Request, args ...any) {
@@ -48,7 +33,6 @@ func main() {
 
 	c.ResponseLoggingFunction = func(ctx context.Context, resp *http.Response, args ...any) {}
 
-	// Create the AEP-Terraform provider.
 	p, err := provider.NewProvider(&cfg, c, version)
 	if err != nil {
 		log.Fatal(err.Error())
@@ -59,9 +43,7 @@ func main() {
 		Debug:   debug,
 	}
 
-	// Serve the provider.
 	err = providerserver.Serve(context.Background(), p.Provider, opts)
-
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
If the provider can be run standalone, it's much easier for people to experiment with. They can do a download from Terraform Registry and immediately start working.